### PR TITLE
Add a custom theme with dark mode and light mode for app

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:fitpage/routes/app_pages.dart';
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'themes/app_themes.dart'; // Import the new themes file
 
 void main() {
   runApp(const FitPageDemo());
@@ -12,11 +13,9 @@ class FitPageDemo extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return GetMaterialApp(
-      theme: ThemeData(
-          appBarTheme: const AppBarTheme(
-        iconTheme: IconThemeData(color: Colors.black),
-        color: Colors.deepPurpleAccent, //<-- SEE HERE
-      )),
+      theme: lightTheme, // Use the light theme
+      darkTheme: darkTheme, // Define the dark theme
+      themeMode: ThemeMode.system, // Switch between light and dark themes
       debugShowCheckedModeBanner: true,
       getPages: AppPages.routes,
       initialRoute: Routes.home,

--- a/lib/modules/stock_scan_home/view/criteria_view.dart
+++ b/lib/modules/stock_scan_home/view/criteria_view.dart
@@ -26,7 +26,7 @@ class CriteriaView extends GetView<StockScanHomeController> {
           child: Padding(
             padding: const EdgeInsets.all(10.0),
             child: Card(
-              color: Colors.black,
+              color: Theme.of(context).cardColor,
               child: Padding(
                 padding: const EdgeInsets.all(10.0),
                 child: Column(
@@ -38,7 +38,7 @@ class CriteriaView extends GetView<StockScanHomeController> {
                       height: 60,
                       width: Get.width,
                       child: ColoredBox(
-                        color: const Color(0xff1686B0),
+                        color: Theme.of(context).primaryColor,
                         child: Padding(
                           padding: const EdgeInsets.all(10.0),
                           child: Column(
@@ -49,8 +49,7 @@ class CriteriaView extends GetView<StockScanHomeController> {
                               Text(
                                 controller.stockScanList[indexOfSection].name ??
                                     '',
-                                style: textTheme.titleMedium
-                                    ?.copyWith(color: Colors.white),
+                                style: textTheme.titleMedium,
                               ),
                               Text(
                                   controller

--- a/lib/modules/stock_scan_home/view/sub_criteria_view.dart
+++ b/lib/modules/stock_scan_home/view/sub_criteria_view.dart
@@ -27,7 +27,7 @@ class SubCriteriaView extends StatelessWidget {
       case SubCriteriaType.valueType:
         final valuesList = variableData['values'] as List;
         return Scaffold(
-          backgroundColor: Colors.black,
+          backgroundColor: Theme.of(context).backgroundColor,
           appBar: AppBar(
             title: const Text(
               "Sub Criteria View ",
@@ -75,7 +75,7 @@ class SubCriteriaView extends StatelessWidget {
         final String title = variableData['study_type'];
         final String parameterName = variableData['parameter_name'];
         return Scaffold(
-            backgroundColor: Colors.black,
+            backgroundColor: Theme.of(context).backgroundColor,
             appBar: AppBar(
               title: const Text(
                 "Sub Criteria View ",

--- a/lib/modules/stock_scan_home/view/widget/plain_text_section.dart
+++ b/lib/modules/stock_scan_home/view/widget/plain_text_section.dart
@@ -17,7 +17,7 @@ class PlainTextSection extends StatelessWidget {
     return criteriaList.length == 1 || criteriaList.last == criteriaList[index]
         ? Text(
             criteriaList[index].text ?? '',
-            style: const TextStyle(color: Colors.white),
+            style: textTheme.bodyLarge,
           )
         : Column(
             mainAxisAlignment: MainAxisAlignment.start,
@@ -25,11 +25,11 @@ class PlainTextSection extends StatelessWidget {
             children: [
               Text(
                 criteriaList[index].text ?? '',
-                style: const TextStyle(color: Colors.white),
+                style: textTheme.bodyLarge,
               ),
               Text(
                 'and',
-                style: textTheme.labelSmall?.copyWith(color: Colors.white),
+                style: textTheme.labelSmall,
               )
             ],
           );

--- a/lib/modules/stock_scan_home/view/widget/variable_text_section.dart
+++ b/lib/modules/stock_scan_home/view/widget/variable_text_section.dart
@@ -51,8 +51,8 @@ class VariableTextSection extends StatelessWidget {
                   Get.toNamed(Routes.subCriteriaView,
                       arguments: {"selectedData": variableData});
                 },
-              style: const TextStyle(
-                color: Color(0xff551A8B),
+              style: textTheme.bodyLarge?.copyWith(
+                color: Theme.of(context).colorScheme.secondary,
                 decoration: TextDecoration.underline,
               ),
             ));
@@ -68,8 +68,8 @@ class VariableTextSection extends StatelessWidget {
                     Get.toNamed(Routes.subCriteriaView,
                         arguments: {"selectedData": variableData});
                   },
-                style: const TextStyle(
-                  color: Color(0xff551A8B),
+                style: textTheme.bodyLarge?.copyWith(
+                  color: Theme.of(context).colorScheme.secondary,
                   decoration: TextDecoration.underline,
                 ),
               ));

--- a/lib/themes/app_themes.dart
+++ b/lib/themes/app_themes.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+final ThemeData lightTheme = ThemeData(
+  brightness: Brightness.light,
+  primaryColor: Colors.blue,
+  backgroundColor: Colors.white,
+  cardColor: Colors.white,
+  textTheme: TextTheme(
+    titleMedium: TextStyle(color: Colors.black),
+    bodySmall: TextStyle(color: Colors.black54),
+    bodyLarge: TextStyle(color: Colors.black),
+    labelSmall: TextStyle(color: Colors.black54),
+  ),
+);
+
+final ThemeData darkTheme = ThemeData(
+  brightness: Brightness.dark,
+  primaryColor: Colors.blueGrey,
+  backgroundColor: Colors.black,
+  cardColor: Colors.black,
+  textTheme: TextTheme(
+    titleMedium: TextStyle(color: Colors.white),
+    bodySmall: TextStyle(color: Colors.white70),
+    bodyLarge: TextStyle(color: Colors.white),
+    labelSmall: TextStyle(color: Colors.white70),
+  ),
+);


### PR DESCRIPTION
Add a custom theme with dark mode and light mode for the app.

* **Main Application**:
  - Import the new themes file in `lib/main.dart`.
  - Update `GetMaterialApp` to use `lightTheme` and `darkTheme`.
  - Set `themeMode` to `ThemeMode.system` to switch between light and dark themes.

* **Themes Definition**:
  - Create `lib/themes/app_themes.dart` to define `lightTheme` and `darkTheme`.

* **Criteria View**:
  - Update `Card` widget's `color` property to use the theme's card color.
  - Update `ColoredBox` widget's `color` property to use the theme's primary color.
  - Update `Text` widget's `style` property to use the theme's text styles.

* **Sub Criteria View**:
  - Update `Scaffold` widget's `backgroundColor` property to use the theme's background color.

* **Plain Text Section**:
  - Update `Text` widget's `style` property to use the theme's text styles.

* **Variable Text Section**:
  - Update `TextSpan` widget's `style` property to use the theme's text styles.
  - Replace the static color `Color(0xff551A8B)` with a color from the theme context.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/oddmentiusmaximus/fitpage_demo/pull/1?shareId=62587649-d355-4529-bedc-9c7a152989a0).